### PR TITLE
Fix argocd sync problem

### DIFF
--- a/cluster-scope/overlays/moc-infra/externalsecrets/github-secret.yaml
+++ b/cluster-scope/overlays/moc-infra/externalsecrets/github-secret.yaml
@@ -12,6 +12,11 @@ spec:
     name: github-secret
     creationPolicy: Owner
     deletionPolicy: Retain
+    template:
+      metadata:
+        annotations:
+         argocd.argoproj.io/compare-options: IgnoreExtraneous
+         argocd.argoproj.io/sync-options: Prune=false
   data:
     - secretKey: clientSecret
       remoteRef:


### PR DESCRIPTION
This tells argocd to not manage the secret generated by the externalsecret so then the openshift generated "v4-0-config-user-idp-0-client-secret" is not touched by argocd.