### PR TITLE
Set spec.targetNamespaces for the operatorgroup

### DIFF
--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-cert-manager-operator/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-cert-manager-operator/operatorgroup.yaml
@@ -3,4 +3,5 @@ kind: OperatorGroup
 metadata:
   name: openshift-cert-manager-operator
 spec:
-  upgradeStrategy: Default
+  targetNamespaces:
+  - "cert-manager-operator"


### PR DESCRIPTION
Without this, you'll see this error message:

"AllNamespaces InstallModeType not supported, cannot configure to watch all namespaces"