### PR TITLE
Update longhorn storage profile

### DIFF
--- a/cluster-scope/base/cdi.kubevirt.io/storageprofiles/longhorn/kustomization.yaml
+++ b/cluster-scope/base/cdi.kubevirt.io/storageprofiles/longhorn/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - storageprofile.yaml

--- a/cluster-scope/base/cdi.kubevirt.io/storageprofiles/longhorn/storageprofile.yaml
+++ b/cluster-scope/base/cdi.kubevirt.io/storageprofiles/longhorn/storageprofile.yaml
@@ -1,0 +1,11 @@
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: StorageProfile
+metadata:
+  labels:
+    app: containerized-data-importer
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/managed-by: cdi-controller
+    app.kubernetes.io/part-of: hyperconverged-cluster
+    cdi.kubevirt.io: ""
+  name: longhorn
+spec: {}

--- a/cluster-scope/overlays/moc-infra/kustomization.yaml
+++ b/cluster-scope/overlays/moc-infra/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
 - ../../base/config.openshift.io/oauths/cluster
 - ../../base/config.openshift.io/apiservers/cluster
+- ../../base/cdi.kubevirt.io/storageprofiles/longhorn
 - ../../base/operator.openshift.io/ingresscontrollers/default
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-sudoer
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-reader/
@@ -28,6 +29,7 @@ patches:
   - path: oauths/cluster_patch.yaml
   - path: groups/cluster-admins.yaml
   - path: groups/cluster-readers.yaml
+  - path: storageprofiles/longhorn-patch.yaml
   - target:
       kind: APIServer
       name: cluster

--- a/cluster-scope/overlays/moc-infra/storageprofiles/longhorn-patch.yaml
+++ b/cluster-scope/overlays/moc-infra/storageprofiles/longhorn-patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: StorageProfile
+metadata:
+  name: longhorn
+spec:
+  claimPropertySets:
+  - accessModes:
+    - ReadWriteMany
+    volumeMode: Filesystem


### PR DESCRIPTION
This updates the specs with claimPropertySets to set accessModes. Without this the datavolume isn't created, or we'll have to explicity set this in each datavolume created.

https://docs.openshift.com/container-platform/4.13/virt/virtual_machines/virtual_disks/virt-creating-data-volumes.html#virt-customizing-storage-profile_virt-creating-data-volumes