### PR TITLE
Configure metallb for moc-infra cluster

### DIFF
--- a/app-of-apps/clusters/moc-infra/metallb/application.yaml
+++ b/app-of-apps/clusters/moc-infra/metallb/application.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: metallb
+spec:
+  destination:
+    name: in-cluster
+    namespace: openshift-gitops
+  project: default
+  source:
+    path: metallb/overlays/moc-infra
+    repoURL: https://github.com/CCI-MOC/moc-infra-config.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false
+    - ApplyOutOfSyncOnly=true

--- a/app-of-apps/clusters/moc-infra/metallb/kustomization.yaml
+++ b/app-of-apps/clusters/moc-infra/metallb/kustomization.yaml
@@ -1,7 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cluster-resources
-  - metallb
-
-nameSuffix: -moc-infra
+- application.yaml

--- a/metallb/base/kustomization.yaml
+++ b/metallb/base/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: metallb-system
 resources:
-  - cluster-resources
-  - metallb
-
-nameSuffix: -moc-infra
+  - metallb.yaml

--- a/metallb/base/metallb.yaml
+++ b/metallb/base/metallb.yaml
@@ -1,0 +1,4 @@
+apiVersion: metallb.io/v1beta1
+kind: MetalLB
+metadata:
+  name: metallb

--- a/metallb/overlays/moc-infra/ipaddresspools/kustomization.yaml
+++ b/metallb/overlays/moc-infra/ipaddresspools/kustomization.yaml
@@ -1,7 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cluster-resources
-  - metallb
-
-nameSuffix: -moc-infra
+  - neu-vlan-127.yaml

--- a/metallb/overlays/moc-infra/ipaddresspools/neu-vlan-127.yaml
+++ b/metallb/overlays/moc-infra/ipaddresspools/neu-vlan-127.yaml
@@ -1,0 +1,7 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: neu-vlan-127
+spec:
+  addresses:
+  - 129.10.5.10-129.10.5.40

--- a/metallb/overlays/moc-infra/kustomization.yaml
+++ b/metallb/overlays/moc-infra/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metallb-system
+resources:
+  - ../../base
+  - ipaddresspools
+  - l2advertisements

--- a/metallb/overlays/moc-infra/l2advertisements/kustomization.yaml
+++ b/metallb/overlays/moc-infra/l2advertisements/kustomization.yaml
@@ -1,7 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cluster-resources
-  - metallb
-
-nameSuffix: -moc-infra
+  - neu-vlan-127.yaml

--- a/metallb/overlays/moc-infra/l2advertisements/neu-vlan-127.yaml
+++ b/metallb/overlays/moc-infra/l2advertisements/neu-vlan-127.yaml
@@ -1,0 +1,7 @@
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: neu-vlan-127
+spec:
+  ipAddressPools:
+   - neu-vlan-127


### PR DESCRIPTION
This commit adds the configuration for metallb and an argocd app to manage metallb configuration.

https://docs.openshift.com/container-platform/4.15/networking/metallb/about-advertising-ipaddresspool.html#nw-metallb-configure-with-L2-advertisement_about-advertising-ip-address-pool