### PR TITLE
Install nmstate

### DIFF
--- a/cluster-scope/base/core/namespaces/openshift-nmstate/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-nmstate/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/openshift-nmstate/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-nmstate/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-nmstate

--- a/cluster-scope/base/nmstate.io/nmstates/nmstate/kustomization.yaml
+++ b/cluster-scope/base/nmstate.io/nmstates/nmstate/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - nmstate.yaml

--- a/cluster-scope/base/nmstate.io/nmstates/nmstate/nmstate.yaml
+++ b/cluster-scope/base/nmstate.io/nmstates/nmstate/nmstate.yaml
@@ -1,0 +1,5 @@
+apiVersion: nmstate.io/v1
+kind: NMState
+metadata:
+  name: nmstate
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-nmstate/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-nmstate/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-nmstate/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-nmstate/operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-nmstate
+  namespace: openshift-nmstate
+spec:
+  targetNamespaces:
+    - openshift-nmstate

--- a/cluster-scope/base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-nmstate
+resources:
+- subscriptions.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator/subscriptions.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator/subscriptions.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+    name: kubernetes-nmstate-operator
+    namespace: openshift-nmstate
+spec:
+    channel: stable
+    installPlanApproval: Automatic
+    name: kubernetes-nmstate-operator
+    source: redhat-operators
+    sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/nmstate/kustomization.yaml
+++ b/cluster-scope/bundles/nmstate/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  massopen.cloud/bundle: metallb
+resources:
+- ../../base/core/namespaces/openshift-nmstate/
+- ../../base/nmstate.io/nmstates/nmstate
+- ../../base/operators.coreos.com/operatorgroups/openshift-nmstate
+- ../../base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator

--- a/cluster-scope/overlays/moc-infra/kustomization.yaml
+++ b/cluster-scope/overlays/moc-infra/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
 - ../../bundles/external-secrets
 - ../../bundles/longhorn
 - ../../bundles/metallb-system
+- ../../bundles/nmstate
 - ../../bundles/openshift-gitops-operator
 - ../../bundles/openshift-cert-manager-operator/
 - ../../bundles/openshift-cnv


### PR DESCRIPTION
We need to configure network bridges on the hosts so that we can attach VMs and pods to external networks.