### PR TITLE
update to latest 4.15 that I see on the web interface

### DIFF
--- a/cluster-scope/overlays/moc-infra/clusterversion.yaml
+++ b/cluster-scope/overlays/moc-infra/clusterversion.yaml
@@ -1,0 +1,9 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  name: version
+spec:
+  channel: stable-4.15
+  desirtedUpdate:
+    version: 4.15.45
+  clusterID: a65776df-7d29-413a-94bf-277ea6522b14

--- a/cluster-scope/overlays/moc-infra/kustomization.yaml
+++ b/cluster-scope/overlays/moc-infra/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
 - ../../bundles/openshift-cert-manager-operator/
 - ../../bundles/openshift-cnv
 - ../../cert-manager.io/clusterissuers/letsencrypt-production-dns01
+- clusterversion.yaml
 - clustersecretstore/clustersecretstore.yaml
 - certificates/
 - externalsecrets/


### PR DESCRIPTION
The web interface says 4.15.45 is the most recent version I can go to, however the redhat update path calculator says I can go up to 4.15.46. I am just picking the lower version of the 2. 

I put in the update path calculator that I want to go from 4.15.0 to the latest which it says 4.17.18. Not sure if I want to yet, but at least I want to run the latest 4.15

<img width="690" alt="image" src="https://github.com/user-attachments/assets/e6a2079b-5323-45fd-becd-307880d9834f" />

