### PR TITLE
Fix broken openshift gitops authentication due to the incorrect serve…

### DIFF
--- a/cluster-scope/base/argoproj.io/argocds/openshift-gitops/argocd.yaml
+++ b/cluster-scope/base/argoproj.io/argocds/openshift-gitops/argocd.yaml
@@ -1,0 +1,122 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: openshift-gitops
+  namespace: openshift-gitops
+spec:
+  applicationSet:
+    resources:
+      limits:
+        cpu: "2"
+        memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 512Mi
+    webhookServer:
+      ingress:
+        enabled: false
+      route:
+        enabled: false
+  controller:
+    resources:
+      limits:
+        cpu: "2"
+        memory: 2Gi
+      requests:
+        cpu: 250m
+        memory: 1Gi
+  extraConfig:
+    application.instanceLabelKey: argocd.argoproj.io/instance
+  grafana:
+    enabled: false
+    ingress:
+      enabled: false
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+    route:
+      enabled: false
+  ha:
+    enabled: false
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+  monitoring:
+    enabled: false
+  notifications:
+    enabled: false
+  prometheus:
+    enabled: false
+    ingress:
+      enabled: false
+    route:
+      enabled: false
+  rbac:
+    defaultPolicy: ""
+    policy: |
+      g, system:cluster-admins, role:admin
+      g, cluster-admins, role:admin
+    scopes: '[groups]'
+  redis:
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+  repo:
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+  resourceExclusions: |
+    - apiGroups:
+      - tekton.dev
+      clusters:
+      - '*'
+      kinds:
+      - TaskRun
+      - PipelineRun
+  server:
+    autoscale:
+      enabled: false
+    grpc:
+      ingress:
+        enabled: false
+    host: <set host>
+    ingress:
+      enabled: false
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    route:
+      enabled: true
+    service:
+      type: ""
+  sso:
+    dex:
+      openShiftOAuth: true
+      resources:
+        limits:
+          cpu: 500m
+          memory: 256Mi
+        requests:
+          cpu: 250m
+          memory: 128Mi
+    provider: dex

--- a/cluster-scope/base/argoproj.io/argocds/openshift-gitops/kustomization.yaml
+++ b/cluster-scope/base/argoproj.io/argocds/openshift-gitops/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - argocd.yaml

--- a/cluster-scope/overlays/moc-infra/argocds/openshift-gitops_patch.yaml
+++ b/cluster-scope/overlays/moc-infra/argocds/openshift-gitops_patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: openshift-gitops
+  namespace: openshift-gitops
+spec:
+  server:
+    host: openshift-gitops-server-openshift-gitops.apps.moc-infra.massopen.cloud

--- a/cluster-scope/overlays/moc-infra/kustomization.yaml
+++ b/cluster-scope/overlays/moc-infra/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- ../../base/argoproj.io/argocds/openshift-gitops
 - ../../base/config.openshift.io/oauths/cluster
 - ../../base/config.openshift.io/apiservers/cluster
 - ../../base/cdi.kubevirt.io/storageprofiles/longhorn
@@ -29,6 +30,7 @@ resources:
 - longhorn-settings
 
 patches:
+  - path: argocds/openshift-gitops_patch.yaml
   - path: oauths/cluster_patch.yaml
   - path: groups/cluster-admins.yaml
   - path: groups/cluster-readers.yaml


### PR DESCRIPTION
…r attribute

in the `argocd` resource `openshift-gitops`. We already made this change by directly, so this PR just commits it to the repo.

Closes https://github.com/CCI-MOC/moc-infra-config/issues/29