### PR TITLE
Insert secret into SNMP exporter configmap

### DIFF
--- a/moc-monitoring/base/kustomization.yaml
+++ b/moc-monitoring/base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - prometheus
 - blackbox-exporter
 - ipmi-exporter
+- snmp-exporter

--- a/moc-monitoring/base/snmp-exporter/configmap.yaml
+++ b/moc-monitoring/base/snmp-exporter/configmap.yaml
@@ -1,16 +1,16 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: snmp-generator-config
+  name: snmp-generator-config-template
 data:
-  generator.yml: |
+  generator_template.yml: |
     auths:
       public_v1:
         version: 1
-        community: "<insert-secret-here>"
+        community: "{{ .Env.IPMI_SNMP_COMMUNITY }}"
       public_v2:
         version: 2
-        community: "<insert-secret-here>"
+        community: "{{ .Env.IPMI_SNMP_COMMUNITY }}"
 
     modules:
       system:

--- a/moc-monitoring/base/snmp-exporter/deployment.yaml
+++ b/moc-monitoring/base/snmp-exporter/deployment.yaml
@@ -15,22 +15,38 @@ spec:
       volumes:
         - name: config-storage
           emptyDir: {}
-        - name: generator-config
+        - name: snmp-generator-config-template
           configMap:
-            name: snmp-generator-config
+            name: snmp-generator-config-template
       initContainers:
+        - name: insert-secret
+          image: docker.io/gomplate/gomplate:v4.3.0-alpine
+          volumeMounts:
+            - name: config-storage
+              mountPath: /config
+            - name: snmp-generator-config-template
+              mountPath: /config-template
+          command:
+            - sh
+            - -c
+            - |
+              gomplate -f /config-template/generator_template.yml -o /config/generator.yml
+          env:
+            - name: IPMI_SNMP_COMMUNITY
+              valueFrom:
+                secretKeyRef:
+                  name: ipmi-snmp-community
+                  key: community
         - name: snmp-config-generator
           image: ghcr.io/ocp-on-nerc/snmp-config-generator:latest
           command:
             - sh
             - -c
             - |
-              generator generate -m /mibs -g /config/generator.yml -o /config-output/snmp.yml
+              generator generate -m /mibs -g /config-output/generator.yml -o /config-output/snmp.yml
           volumeMounts:
             - name: config-storage
               mountPath: /config-output
-            - name: generator-config
-              mountPath: /config
       containers:
         - name: snmp-exporter
           image: quay.io/prometheus/snmp-exporter:latest

--- a/moc-monitoring/overlays/moc-infra/externalsecrets/ipmi-community.yaml
+++ b/moc-monitoring/overlays/moc-infra/externalsecrets/ipmi-community.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ipmi-community-es
+spec:
+  secretStoreRef:
+    name: aws-secret-store
+    kind: ClusterSecretStore
+  refreshInterval: "1h"
+  target:
+    name: ipmi-snmp-community
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        annotations:
+         argocd.argoproj.io/compare-options: IgnoreExtraneous
+         argocd.argoproj.io/sync-options: Prune=false
+  data:
+    - secretKey: community
+      remoteRef:
+        key: cluster/moc-infra/ipmi-community-string
+        property: community

--- a/moc-monitoring/overlays/moc-infra/externalsecrets/kustomization.yaml
+++ b/moc-monitoring/overlays/moc-infra/externalsecrets/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - idrac-credentials.yaml
+  - ipmi-community.yaml


### PR DESCRIPTION
This PR adds an external secret for the community string which is inserted into the snmp-exporter config.

This also updates the kustomization file so snmp-exporter is deployed by argocd.