### PR TITLE
Integrated Alertmanager into monitoring setup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+export PATH="$PWD/bin:$PATH"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+moc-monitoring/overlays/testing/
+bin

--- a/moc-monitoring/base/alert-manager/configmap.yaml
+++ b/moc-monitoring/base/alert-manager/configmap.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alertmanager-config
+data:
+  alertmanager.yaml: |
+    global:
+      resolve_timeout: 5m
+
+    route:
+      group_by: ['instance']
+      group_wait: 1s
+      group_interval: 5m
+      repeat_interval: 4h
+      receiver: 'slack-alert-notifications'
+      routes:
+      - receiver: 'slack-alert-notifications'
+        matchers:
+          - service = "idrac"
+
+    receivers:
+    - name: 'slack-alert-notifications'
+      slack_configs:
+      - api_url_file: /etc/alertmanager/secrets/slack_webhook_url
+        send_resolved: true
+        title: '[{{ if eq .Status "firing" }}🔥{{ else }}✅{{ end }}] {{ .CommonLabels.alertname }}'
+        text: >-
+          {{ range .Alerts }}
+          *Status:* {{ .Status | title }}
+          *Summary:* {{ .Annotations.summary }}
+          *Description:* {{ .Annotations.description }}
+          *Server:* {{ .Labels.instance }}
+          *Severity:* {{ .Labels.severity | title }}
+          {{ end }}

--- a/moc-monitoring/base/alert-manager/deployment.yaml
+++ b/moc-monitoring/base/alert-manager/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alertmanager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alertmanager
+  template:
+    metadata:
+      labels:
+        app: alertmanager
+    spec:
+      containers:
+      - name: alertmanager
+        image: quay.io/prometheus/alertmanager:v0.25.0
+        args:
+        - "--config.file=/etc/alertmanager/alertmanager.yaml"
+        - "--storage.path=/alertmanager"
+        ports:
+        - containerPort: 9093
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/alertmanager
+        - name: storage-volume
+          mountPath: /alertmanager
+        - name: secret-slack-webhook
+          mountPath: /etc/alertmanager/secrets
+          readOnly: true
+      volumes:
+      - name: secret-slack-webhook
+        secret:
+          secretName: alertmanager-slack-webhook
+          items:
+          - key: webhookURL
+            path: slack_webhook_url
+      - name: config-volume
+        configMap:
+          name: alertmanager-config
+      - name: storage-volume
+        persistentVolumeClaim:
+          claimName: alertmanager-pvc

--- a/moc-monitoring/base/alert-manager/kustomization.yaml
+++ b/moc-monitoring/base/alert-manager/kustomization.yaml
@@ -6,7 +6,4 @@ resources:
 - deployment.yaml
 - service.yaml
 - pvc.yaml
-- route.yaml
-- configmaps
-- dashboards
-- alerting
+- configmap.yaml

--- a/moc-monitoring/base/alert-manager/pvc.yaml
+++ b/moc-monitoring/base/alert-manager/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: alertmanager-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/moc-monitoring/base/alert-manager/service.yaml
+++ b/moc-monitoring/base/alert-manager/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager
+spec:
+  selector:
+    app: alertmanager
+  ports:
+  - port: 9093
+    targetPort: 9093

--- a/moc-monitoring/base/grafana/alerting/alert-contactpoints.yaml
+++ b/moc-monitoring/base/grafana/alerting/alert-contactpoints.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-contact-points
+data:
+  contact_points.yaml: |
+    apiVersion: 1
+    contactPoints:
+      - name: slack-notifications
+        receivers:
+          - uid: slack-notifications
+            type: slack
+            settings:
+              url: https://hooks.slack.com/services/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
+              username: Grafana
+              title: >-
+                [{{ if eq .Status "firing" }}🔥{{ else }}✅{{ end }}] 
+                {{ .CommonLabels.alertname }}
+              text: >-
+                {{ range .Alerts }}
+                *Status:* {{ .Status | title }}
+                *Summary:* {{ .Annotations.summary }}
+                *Description:* {{ .Annotations.description }}
+                *Server:* {{ .Labels.instance }}
+                *Severity:* {{ .Labels.severity | title }}
+                {{ end }}

--- a/moc-monitoring/base/grafana/alerting/alert-notification-policies.yaml
+++ b/moc-monitoring/base/grafana/alerting/alert-notification-policies.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-notification-policies
+data:
+  notification_policies.yaml: |
+    apiVersion: 1
+    policies:
+      - name: iDRAC Alerts Policy
+        receiver: slack-notifications
+        group_by: ['alertname', 'instance']
+        group_wait: 30s
+        group_interval: 5m
+        repeat_interval: 4h
+        routes:
+          - receiver: slack-notifications
+            matchers:
+              - service = "idrac"

--- a/moc-monitoring/base/grafana/alerting/alert-rules.yaml
+++ b/moc-monitoring/base/grafana/alerting/alert-rules.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-alerting-rules
+data:
+  idrac_alerts.yaml: |
+    apiVersion: 1
+    groups:
+        - orgId: 1
+          name: Server Monitoring
+          folder: iDRAC Health Alerts
+          interval: 1m
+          rules:
+            - uid: ceim55agrp81sc
+              title: idRAC Critical Health Status
+              condition: C
+              data:
+                - refId: A
+                  relativeTimeRange:
+                    from: 600
+                    to: 0
+                  datasourceUid: PBFA97CFB590B2093
+                  model:
+                    disableTextWrap: false
+                    editorMode: builder
+                    expr: idrac_system_health{job="idrac_exporter", status="Critical"}
+                    fullMetaSearch: false
+                    includeNullMetadata: true
+                    instant: true
+                    intervalMs: 1000
+                    legendFormat: __auto
+                    maxDataPoints: 43200
+                    range: false
+                    refId: A
+                    useBackend: false
+                - refId: C
+                  datasourceUid: __expr__
+                  model:
+                    conditions:
+                        - evaluator:
+                            params:
+                                - 0
+                            type: gt
+                          operator:
+                            type: and
+                          query:
+                            params:
+                                - C
+                          reducer:
+                            params: []
+                            type: last
+                          type: query
+                    datasource:
+                        type: __expr__
+                        uid: __expr__
+                    expression: A
+                    intervalMs: 1000
+                    maxDataPoints: 43200
+                    refId: C
+                    type: threshold
+              noDataState: NoData
+              execErrState: Error
+              for: 1m
+              annotations:
+                description: Alert triggered when idrac_system_health becomes "Critical"
+                summary: idrac_system_health is Critical
+              isPaused: false
+              notification_settings:
+                receiver: slack-notifications

--- a/moc-monitoring/base/grafana/alerting/kustomization.yaml
+++ b/moc-monitoring/base/grafana/alerting/kustomization.yaml
@@ -3,10 +3,6 @@ kind: Kustomization
 namespace: moc-monitoring
 
 resources:
-- deployment.yaml
-- service.yaml
-- pvc.yaml
-- route.yaml
-- configmaps
-- dashboards
-- alerting
+- alert-contactpoints.yaml
+- alert-notification-policies.yaml
+- alert-rules.yaml

--- a/moc-monitoring/base/grafana/deployment.yaml
+++ b/moc-monitoring/base/grafana/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: grafana
-          image: grafana/grafana:latest
+          image: grafana/grafana:10.4.2
           ports:
             - containerPort: 3000
           volumeMounts:

--- a/moc-monitoring/base/kustomization.yaml
+++ b/moc-monitoring/base/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
 - blackbox-exporter
 - ipmi-exporter
 - snmp-exporter
+- alert-manager
+- grafana

--- a/moc-monitoring/overlays/moc-infra/alerting/grafana-alerting-patch.yaml
+++ b/moc-monitoring/overlays/moc-infra/alerting/grafana-alerting-patch.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+spec:
+  template:
+    spec:
+      containers:
+      - name: grafana
+        env:
+        - name: GF_UNIFIED_ALERTING_ENABLED
+          value: "true"
+        - name: GF_ALERTING_ENABLED
+          value: "false"
+        - name: GF_FEATURE_TOGGLES_ENABLE
+          value: "ngalert"
+        - name: GF_PATHS_PROVISIONING
+          value: "/etc/grafana/provisioning"
+        - name: GF_UNIFIED_ALERTING_PROVISIONING_ENABLED
+          value: "true"
+        volumeMounts:
+        - name: grafana-alerting-rules
+          mountPath: /etc/grafana/provisioning/alerting/rules.yaml
+          subPath: idrac_alerts.yaml
+        - name: grafana-contact-points
+          mountPath: /etc/grafana/provisioning/alerting/contact_points.yaml
+          subPath: contact_points.yaml
+        - name: grafana-notification-policies
+          mountPath: /etc/grafana/provisioning/alerting/notification_policies.yaml
+          subPath: notification_policies.yaml
+      volumes:
+      - name: grafana-alerting-rules
+        configMap:
+          name: grafana-alerting-rules
+      - name: grafana-contact-points
+        configMap:
+          name: grafana-contact-points
+      - name: grafana-notification-policies
+        configMap:
+          name: grafana-notification-policies

--- a/moc-monitoring/overlays/moc-infra/alerting/grafana-external-alertmanager-patch.yaml
+++ b/moc-monitoring/overlays/moc-infra/alerting/grafana-external-alertmanager-patch.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+spec:
+  template:
+    spec:
+      containers:
+      - name: grafana
+        env:
+        - name: GF_UNIFIED_ALERTING_EXTERNAL_ALERTMANAGER_ENABLED
+          value: "true"
+        - name: GF_UNIFIED_ALERTING_EXTERNAL_ALERTMANAGERS
+          value: "http://alertmanager.moc-monitoring.svc:9093"

--- a/moc-monitoring/overlays/moc-infra/alerting/idrac-exporter-patch.yaml
+++ b/moc-monitoring/overlays/moc-infra/alerting/idrac-exporter-patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: idrac-exporter
+spec:
+  template:
+    spec:
+      imagePullSecrets:
+      - name: docker-registry-creds

--- a/moc-monitoring/overlays/moc-infra/alerting/kustomization.yaml
+++ b/moc-monitoring/overlays/moc-infra/alerting/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: moc-monitoring
+
+resources:
+- ../../base
+- ../moc-infra/externalsecrets
+
+patches:
+- path: idrac-exporter-patch.yaml
+  target:
+    kind: Deployment
+    name: idrac-exporter
+- path: grafana-alerting-patch.yaml
+  target:
+    kind: Deployment
+    name: grafana
+- path: grafana-external-alertmanager-patch.yaml
+  target:
+    kind: Deployment
+    name: grafana
+- path: prometheus-alertmanager-patch.yaml
+  target:
+    kind: ConfigMap
+    name: prometheus-config

--- a/moc-monitoring/overlays/moc-infra/alerting/prometheus-alertmanager-patch.yaml
+++ b/moc-monitoring/overlays/moc-infra/alerting/prometheus-alertmanager-patch.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 1m
+      scrape_timeout: 1m
+      evaluation_interval: 1m
+
+    alerting:
+      alertmanagers:
+        - static_configs:
+          - targets:
+            - alertmanager.moc-monitoring.svc:9093
+
+    rule_files:
+      - /etc/prometheus/rules/*.yaml
+
+    scrape_configs:
+      - job_name: prometheus
+        static_configs:
+          - targets: ["localhost:9090"]
+      
+      - job_name: alertmanager
+        static_configs:
+          - targets: ["alertmanager.moc-monitoring.svc:9093"]
+      
+      - job_name: "idrac_exporter"
+        scrape_interval: 3m
+        scrape_timeout: 2m
+        file_sd_configs:
+        - files:
+          - /etc/prometheus/file_sd/idrac_targets.yaml
+        relabel_configs:
+          - source_labels: [__address__]
+            target_label: __param_target
+          - source_labels: [__param_target]
+            target_label: instance
+          - target_label: __address__
+            replacement: idrac-exporter.moc-monitoring.svc:9348

--- a/moc-monitoring/overlays/moc-infra/externalsecrets/alertmanager-slack-webhook.yaml
+++ b/moc-monitoring/overlays/moc-infra/externalsecrets/alertmanager-slack-webhook.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: alertmanager-slack-webhook-es
+spec:
+  secretStoreRef:
+    
+    name: aws-secret-store
+    kind: ClusterSecretStore
+  refreshInterval: "1h" 
+  target:
+    
+    name: alertmanager-slack-webhook
+    creationPolicy: Owner
+    deletionPolicy: Retain 
+    template:
+      metadata:
+        annotations:
+         argocd.argoproj.io/compare-options: IgnoreExtraneous
+         argocd.argoproj.io/sync-options: Prune=false
+  data:
+    - secretKey: webhookURL 
+      remoteRef:
+        key: cluster/moc-infra/alerts-slack-webhook
+        property: webhook

--- a/moc-monitoring/overlays/moc-infra/externalsecrets/kustomization.yaml
+++ b/moc-monitoring/overlays/moc-infra/externalsecrets/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - idrac-credentials.yaml
   - ipmi-community.yaml
+  - alertmanager-slack-webhook.yaml

--- a/moc-monitoring/overlays/moc-infra/kustomization.yaml
+++ b/moc-monitoring/overlays/moc-infra/kustomization.yaml
@@ -5,3 +5,4 @@ namespace: moc-monitoring
 resources:
 - ../../base
 - externalsecrets
+- alerting


### PR DESCRIPTION
- Adds Grafana env vars and volume mounts for alerting provisioning and external Alertmanager connection to base deployment.
- Added overlay/alerting for alerting logic along with Slack integration.
- Adds Prometheus alerting config and scrape job for Alertmanager to base prometheus configmap.

Addresses CCI-MOC/moc-infra-config#1502