### PR TITLE
Add external url to alertmanager config

### DIFF
--- a/moc-monitoring/base/alert-manager/config/alertmanager.yaml
+++ b/moc-monitoring/base/alert-manager/config/alertmanager.yaml
@@ -2,7 +2,7 @@ global:
   resolve_timeout: 5m
 
 route:
-  group_by: []
+  group_by: ['alertname', 'instance']
   group_wait: 1s
   group_interval: 5m
   repeat_interval: 24h
@@ -17,12 +17,8 @@ receivers:
   slack_configs:
   - api_url_file: /etc/alertmanager/secrets/webhook
     send_resolved: true
-    title: '[{{ if eq .Status "firing" }}🔥{{ else }}✅{{ end }}] {{ .CommonLabels.alertname }}'
+    title: '[{{ if eq .Status "firing" }}Firing: 🔥{{ else }}Resolved: ✅{{ end }}] {{ .CommonLabels.alertname }} on {{ .CommonLabels.instance }}'
     text: >-
       {{ range .Alerts }}
-      *Status:* {{ .Status | title }}
-      *Summary:* {{ .Annotations.summary }}
-      *Description:* {{ .Annotations.description }}
-      *Server:* {{ .Labels.instance }}
-      *Severity:* {{ .Labels.severity | title }}
+        {{ .Annotations.description }}
       {{ end }}

--- a/moc-monitoring/base/alert-manager/deployment.yaml
+++ b/moc-monitoring/base/alert-manager/deployment.yaml
@@ -12,6 +12,7 @@ spec:
         args:
         - "--config.file=/etc/alertmanager/alertmanager.yaml"
         - "--storage.path=/alertmanager"
+        - "--web.external-url=https://alertmanager-moc-monitoring.apps.moc-infra.massopen.cloud"
         ports:
         - name: alertmanager
           containerPort: 9093

--- a/moc-monitoring/base/prometheus/config/prometheus-rules.yaml
+++ b/moc-monitoring/base/prometheus/config/prometheus-rules.yaml
@@ -16,25 +16,9 @@ groups:
       severity: critical
     annotations:
       summary: "System health critical for {{ $labels.instance }}"
-      description: "The System health status for {{ $labels.instance }} is critical. (host: {{ $labels.hostname }}, model: {{ $labels.model }}, Identifier: {{ $labels.unique_id }})"
-
-  - alert: IPMIPowerSupplyRedundancyLost
-    expr: ipmi_sensor_state{name="PS Redundancy", type="Power Supply"} == 2
-    for: 10m
-    labels:
-      severity: critical
-    annotations:
-      summary: "IPMI PSU redundancy lost on {{ $labels.instance }}"
-      description: "Power supply redundancy is lost on {{ $labels.instance }} (sensor: {{ $labels.name }})."
-
-  - alert: IPMIDriveSlotIssue
-    expr: ipmi_sensor_state{type="Drive Slot"} == 2
-    for: 10m
-    labels:
-      severity: critical
-    annotations:
-      summary: "Drive slot issue on {{ $labels.instance }} ({{ $labels.name }})"
-      description: "Drive {{ $labels.name }} on {{ $labels.instance }} reported a fault (state 2)."
+      description: |
+        "The System health status for {{ $labels.instance }} is critical.
+        Host: {{ $labels.hostname }}, Model: {{ $labels.model }}, Identifier: {{ $labels.unique_id }})"
 
   - alert: IDRACChassisAmbientTempHigh
     expr: idrac_sensors_temperature{name="Chassis Ambient Temp"} > 50
@@ -44,7 +28,8 @@ groups:
       severity: warning # Temp might be warning instead of critical
     annotations:
       summary: "iDRAC chassis ambient temperature high for {{ $labels.instance }}"
-      description: "Chassis Ambient Temp on {{ $labels.instance }} is above 50°C ({{ $value }}°C)."
+      description: |
+        "Chassis Ambient Temp on {{ $labels.instance }} is above 50°C ({{ $value }}°C)."
 
   - alert: IDRACMemoryModuleIssue
     expr: idrac_memory_module_health{status!="OK"} * on (instance) group_left(hostname, model, unique_id) idrac_system_machine_info_fixed
@@ -53,7 +38,9 @@ groups:
       severity: critical
     annotations:
       summary: "Memory module issue in {{ $labels.instance }}"
-      description: "Memory module {{ $labels.id }} on system {{ $labels.instance }} is  in {{ $labels.status }} state. More info: (host: {{ $labels.hostname }}, model: {{ $labels.model }}, Identifier: {{ $labels.unique_id }}) ."
+      description: |
+        "Memory module {{ $labels.id }} on system {{ $labels.instance }} is  in {{ $labels.status }} state.
+        Host: {{ $labels.hostname }}, Model: {{ $labels.model }}, Identifier: {{ $labels.unique_id }})"
 
   - alert: IDRACDriveIssue
     expr: idrac_storage_drive_health{status!="OK"} * on (instance) group_left(hostname, model, unique_id) idrac_system_machine_info_fixed
@@ -62,7 +49,29 @@ groups:
       severity: critical
     annotations:
       summary: "Drive issue on {{ $labels.instance }}"
-      description: "Storage device {{ $labels.id }} on system {{ $labels.instance }} is  in {{ $labels.status }} state. More info: (host: {{ $labels.hostname }}, model: {{ $labels.model }}, Identifier: {{ $labels.unique_id }}) ."
+      description: |
+        "Storage device {{ $labels.id }} on system {{ $labels.instance }} is  in {{ $labels.status }} state.
+        Host: {{ $labels.hostname }}, Model: {{ $labels.model }}, Identifier: {{ $labels.unique_id }})"
+
+  - alert: IPMIPowerSupplyRedundancyLost
+    expr: ipmi_sensor_state{name="PS Redundancy", type="Power Supply"} == 2
+    for: 10m
+    labels:
+      severity: critical
+    annotations:
+      summary: "IPMI PSU redundancy lost on {{ $labels.instance }}"
+      description: |
+        "Power supply redundancy is lost on {{ $labels.instance }} (sensor: {{ $labels.name }})."
+
+  - alert: IPMIDriveSlotIssue
+    expr: ipmi_sensor_state{type="Drive Slot"} == 2
+    for: 10m
+    labels:
+      severity: critical
+    annotations:
+      summary: "Drive slot issue on {{ $labels.instance }} ({{ $labels.name }})"
+      description: |
+        "Drive {{ $labels.name }} on {{ $labels.instance }} reported a fault (state 2)."
 
   - alert: IPMIChassisCoolingFault
     expr: ipmi_chassis_cooling_fault_state == 0

--- a/moc-monitoring/base/prometheus/config/prometheus-rules.yaml
+++ b/moc-monitoring/base/prometheus/config/prometheus-rules.yaml
@@ -1,14 +1,22 @@
 groups:
+- name: idrac.recording
+  rules:
+  - record: idrac_system_machine_info_fixed
+    expr: |
+      label_replace(idrac_system_machine_info{manufacturer="Dell Inc."}, "unique_id", "$1", "sku", "(.*)")
+      or
+      label_replace(idrac_system_machine_info{manufacturer!="Dell Inc."}, "unique_id", "$1", "serial", "(.*)")
+
 - name: idrac.alerts
   rules:
   - alert: IDRACSystemHealthCritical
-    expr: idrac_system_health{status="Critical"} * on (instance) group_left(hostname, model, sku) idrac_system_machine_info
+    expr: idrac_system_health{status="Critical"} * on (instance) group_left(hostname, model, unique_id) idrac_system_machine_info_fixed
     for: 10m
     labels:
       severity: critical
     annotations:
-      summary: "iDRAC system health critical for {{ $labels.instance }}"
-      description: "The iDRAC system health status for {{ $labels.instance }} is critical. (host: {{ $labels.hostname }}, model: {{ $labels.model }}, ServiceTag: {{ $labels.sku }})"
+      summary: "System health critical for {{ $labels.instance }}"
+      description: "The System health status for {{ $labels.instance }} is critical. (host: {{ $labels.hostname }}, model: {{ $labels.model }}, Identifier: {{ $labels.unique_id }})"
 
   - alert: IPMIPowerSupplyRedundancyLost
     expr: ipmi_sensor_state{name="PS Redundancy", type="Power Supply"} == 2
@@ -39,22 +47,22 @@ groups:
       description: "Chassis Ambient Temp on {{ $labels.instance }} is above 50°C ({{ $value }}°C)."
 
   - alert: IDRACMemoryModuleIssue
-    expr: idrac_memory_module_health{status!="OK"} * on (instance) group_left(hostname, model, sku) idrac_system_machine_info
+    expr: idrac_memory_module_health{status!="OK"} * on (instance) group_left(hostname, model, unique_id) idrac_system_machine_info_fixed
     for: 10m
     labels:
       severity: critical
     annotations:
       summary: "Memory module issue in {{ $labels.instance }}"
-      description: "Memory module {{ $labels.id }} on system {{ $labels.instance }} is  in {{ $labels.status }} state. More info: (host: {{ $labels.hostname }}, model: {{ $labels.model }}, SKU: {{ $labels.sku }}) ."
+      description: "Memory module {{ $labels.id }} on system {{ $labels.instance }} is  in {{ $labels.status }} state. More info: (host: {{ $labels.hostname }}, model: {{ $labels.model }}, Identifier: {{ $labels.unique_id }}) ."
 
   - alert: IDRACDriveIssue
-    expr: idrac_storage_drive_health{status!="OK"} * on (instance) group_left(hostname, model, sku) idrac_system_machine_info
+    expr: idrac_storage_drive_health{status!="OK"} * on (instance) group_left(hostname, model, unique_id) idrac_system_machine_info_fixed
     for: 10m
     labels:
       severity: critical
     annotations:
       summary: "Drive issue on {{ $labels.instance }}"
-      description: "Storage device {{ $labels.id }} on system {{ $labels.instance }} is  in {{ $labels.status }} state. More info: (host: {{ $labels.hostname }}, model: {{ $labels.model }}, SKU: {{ $labels.sku }}) ."
+      description: "Storage device {{ $labels.id }} on system {{ $labels.instance }} is  in {{ $labels.status }} state. More info: (host: {{ $labels.hostname }}, model: {{ $labels.model }}, Identifier: {{ $labels.unique_id }}) ."
 
   - alert: IPMIChassisCoolingFault
     expr: ipmi_chassis_cooling_fault_state == 0

--- a/moc-monitoring/base/prometheus/config/prometheus-rules.yaml
+++ b/moc-monitoring/base/prometheus/config/prometheus-rules.yaml
@@ -8,7 +8,7 @@ groups:
       severity: critical
     annotations:
       summary: "iDRAC system health critical for {{ $labels.instance }}"
-      description: "The iDRAC system health status for {{ $labels.instance }} (host: {{ $labels.hostname }}, model: {{ $labels.model }}, SKU: {{ $labels.sku }}) is Critical."
+      description: "The iDRAC system health status for {{ $labels.instance }} is critical. (host: {{ $labels.hostname }}, model: {{ $labels.model }}, ServiceTag: {{ $labels.sku }})"
 
   - alert: IPMIPowerSupplyRedundancyLost
     expr: ipmi_sensor_state{name="PS Redundancy", type="Power Supply"} == 2


### PR DESCRIPTION
that way when we click on the slack notifications it'll take us to a working alertmanager web page.

Additionally, some clean up in the way the message is presented and grouped:
- bring back grouping
- remove redundant information

Mostly some cosmetic improvements