### PR TITLE
Allocate IPMI networks directly to the exporter pods

### DIFF
--- a/cluster-scope/overlays/moc-infra/kustomization.yaml
+++ b/cluster-scope/overlays/moc-infra/kustomization.yaml
@@ -27,6 +27,8 @@ resources:
 - externalsecrets/
 - hyperconverged/kubevirt-hyperconverged.yaml
 - machineconfigs/
+- networkattachmentdefinitions
+- nodenetworkconfigurationpolicies
 - longhorn-settings
 
 patches:

--- a/cluster-scope/overlays/moc-infra/networkattachmentdefinitions/kustomization.yaml
+++ b/cluster-scope/overlays/moc-infra/networkattachmentdefinitions/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- vlan911.yaml
+- vlan912.yaml
+- vlan913.yaml

--- a/cluster-scope/overlays/moc-infra/networkattachmentdefinitions/vlan911.yaml
+++ b/cluster-scope/overlays/moc-infra/networkattachmentdefinitions/vlan911.yaml
@@ -1,0 +1,15 @@
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: ipmi-vlan-911
+  namespace: moc-monitoring
+spec:
+  config: '{
+    "cniVersion": "0.3.1",
+    "type": "macvlan",
+    "master": "vlan911",
+    "mode": "bridge",
+    "ipam": {
+      "type": "static"
+    }
+  }'

--- a/cluster-scope/overlays/moc-infra/networkattachmentdefinitions/vlan912.yaml
+++ b/cluster-scope/overlays/moc-infra/networkattachmentdefinitions/vlan912.yaml
@@ -1,0 +1,15 @@
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: ipmi-vlan-912
+  namespace: moc-monitoring
+spec:
+  config: '{
+    "cniVersion": "0.3.1",
+    "type": "macvlan",
+    "master": "vlan912",
+    "mode": "bridge",
+    "ipam": {
+      "type": "static"
+    }
+  }'

--- a/cluster-scope/overlays/moc-infra/networkattachmentdefinitions/vlan913.yaml
+++ b/cluster-scope/overlays/moc-infra/networkattachmentdefinitions/vlan913.yaml
@@ -1,0 +1,15 @@
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: ipmi-vlan-913
+  namespace: moc-monitoring
+spec:
+  config: '{
+    "cniVersion": "0.3.1",
+    "type": "macvlan",
+    "master": "vlan913",
+    "mode": "bridge",
+    "ipam": {
+      "type": "static"
+    }
+  }'

--- a/cluster-scope/overlays/moc-infra/nodenetworkconfigurationpolicies/ipmi-vlans.yaml
+++ b/cluster-scope/overlays/moc-infra/nodenetworkconfigurationpolicies/ipmi-vlans.yaml
@@ -1,0 +1,27 @@
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: ipmi-vlans
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  desiredState:
+    interfaces:
+    - name: vlan911
+      type: vlan
+      state: up
+      vlan:
+        base-iface: ens3f0np0
+        id: 911
+    - name: vlan912
+      type: vlan
+      state: up
+      vlan:
+        base-iface: ens3f0np0
+        id: 912
+    - name: vlan913
+      type: vlan
+      state: up
+      vlan:
+        base-iface: ens3f0np0
+        id: 913

--- a/cluster-scope/overlays/moc-infra/nodenetworkconfigurationpolicies/kustomization.yaml
+++ b/cluster-scope/overlays/moc-infra/nodenetworkconfigurationpolicies/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ipmi-vlans.yaml

--- a/moc-monitoring/overlays/moc-infra/deployments/idrac-exporter_patch.yaml
+++ b/moc-monitoring/overlays/moc-infra/deployments/idrac-exporter_patch.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: idrac-exporter
+spec:
+  template:
+    metadata:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |
+          [
+            { "name": "ipmi-vlan-911", "ips": ["10.2.0.5/19"] },
+            { "name": "ipmi-vlan-912", "ips": ["10.3.0.5/19"] },
+            { "name": "ipmi-vlan-913", "ips": ["10.4.0.5/19"] }
+          ]

--- a/moc-monitoring/overlays/moc-infra/deployments/ipmi-exporter_patch.yaml
+++ b/moc-monitoring/overlays/moc-infra/deployments/ipmi-exporter_patch.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ipmi-exporter
+spec:
+  template:
+    metadata:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |
+          [
+            { "name": "ipmi-vlan-911", "ips": ["10.2.0.6/19"] },
+            { "name": "ipmi-vlan-912", "ips": ["10.3.0.6/19"] },
+            { "name": "ipmi-vlan-913", "ips": ["10.4.0.6/19"] }
+          ]

--- a/moc-monitoring/overlays/moc-infra/deployments/snmp-exporter_patch.yaml
+++ b/moc-monitoring/overlays/moc-infra/deployments/snmp-exporter_patch.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: snmp-exporter
+spec:
+  template:
+    metadata:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |
+          [
+            { "name": "ipmi-vlan-911", "ips": ["10.2.0.7/19"] },
+            { "name": "ipmi-vlan-912", "ips": ["10.3.0.7/19"] },
+            { "name": "ipmi-vlan-913", "ips": ["10.4.0.7/19"] }
+          ]

--- a/moc-monitoring/overlays/moc-infra/kustomization.yaml
+++ b/moc-monitoring/overlays/moc-infra/kustomization.yaml
@@ -5,3 +5,8 @@ namespace: moc-monitoring
 resources:
 - ../../base
 - externalsecrets
+
+patches:
+  - path: deployments/idrac-exporter_patch.yaml
+  - path: deployments/ipmi-exporter_patch.yaml
+  - path: deployments/snmp-exporter_patch.yaml


### PR DESCRIPTION
We have relied on routing to the ipmi networks but that has relied on the firewalls and has caused issues in the past. This commit creates the vlan interfaces on the hosts and then create networkattachmentdefintions so that the pods can directly communicate on the ipmi network.