### PR TITLE
Preserved alerts with safe joining logic using for fallback mechanism

### DIFF
--- a/moc-monitoring/base/prometheus/config/prometheus-rules.yaml
+++ b/moc-monitoring/base/prometheus/config/prometheus-rules.yaml
@@ -39,7 +39,7 @@ groups:
     annotations:
       summary: "Memory module issue in {{ $labels.instance }}"
       description: |
-        "Memory module {{ $labels.id }} on system {{ $labels.instance }} is  in {{ $labels.status }} state.
+        "Memory module {{ $labels.id }} on system {{ $labels.instance }} is in {{ $labels.status }} state.
         Host: {{ $labels.hostname }}, Model: {{ $labels.model }}, Identifier: {{ $labels.unique_id }})"
 
   - alert: IDRACDriveIssue
@@ -50,52 +50,95 @@ groups:
     annotations:
       summary: "Drive issue on {{ $labels.instance }}"
       description: |
-        "Storage device {{ $labels.id }} on system {{ $labels.instance }} is  in {{ $labels.status }} state.
+        "Storage device {{ $labels.id }} on system {{ $labels.instance }} is in {{ $labels.status }} state.
         Host: {{ $labels.hostname }}, Model: {{ $labels.model }}, Identifier: {{ $labels.unique_id }})"
 
   - alert: IPMIPowerSupplyRedundancyLost
-    expr: ipmi_sensor_state{name="PS Redundancy", type="Power Supply"} == 2
+    expr: |
+      (
+        ipmi_sensor_state{name="PS Redundancy", type="Power Supply"} == 2
+      ) * on (instance) group_left(hostname, model, unique_id) idrac_system_machine_info_fixed
+      or on (instance)
+      (
+        ipmi_sensor_state{name="PS Redundancy", type="Power Supply"} == 2
+      )
     for: 10m
     labels:
       severity: critical
     annotations:
       summary: "IPMI PSU redundancy lost on {{ $labels.instance }}"
       description: |
-        "Power supply redundancy is lost on {{ $labels.instance }} (sensor: {{ $labels.name }})."
+        "Power supply redundancy is lost on {{ $labels.instance }} (sensor: {{ $labels.name }}).
+        {{ if $labels.hostname }}Host: {{ $labels.hostname }}{{ if $labels.model }}, Model: {{ $labels.model }}{{ end }}{{ if $labels.unique_id }}, ID: {{ $labels.unique_id }}{{ end }}{{ else }}Note: Limited system information available{{ end }}"
 
   - alert: IPMIDriveSlotIssue
-    expr: ipmi_sensor_state{type="Drive Slot"} == 2
+    expr: |
+      (
+        ipmi_sensor_state{type="Drive Slot"} == 2
+      ) * on (instance) group_left(hostname, model, unique_id) idrac_system_machine_info_fixed
+      or on (instance)
+      (
+        ipmi_sensor_state{type="Drive Slot"} == 2
+      )
     for: 10m
     labels:
       severity: critical
     annotations:
       summary: "Drive slot issue on {{ $labels.instance }} ({{ $labels.name }})"
       description: |
-        "Drive {{ $labels.name }} on {{ $labels.instance }} reported a fault (state 2)."
+        "Drive {{ $labels.name }} on {{ $labels.instance }} reported a fault (state 2).
+        {{ if $labels.hostname }}Host: {{ $labels.hostname }}{{ if $labels.model }}, Model: {{ $labels.model }}{{ end }}{{ if $labels.unique_id }}, ID: {{ $labels.unique_id }}{{ end }}{{ else }}Note: Limited system information available{{ end }}"
 
   - alert: IPMIChassisCoolingFault
-    expr: ipmi_chassis_cooling_fault_state == 0
+    expr: |
+      (
+        ipmi_chassis_cooling_fault_state == 0
+      ) * on (instance) group_left(hostname, model, unique_id) idrac_system_machine_info_fixed
+      or on (instance)
+      (
+        ipmi_chassis_cooling_fault_state == 0
+      )
     for: 10m
     labels:
       severity: critical
     annotations:
-      summary: "Chassis cooling fault detected in {{ $labels.instance }})"
-      description: "Chassis cooling fault detected on {{ $labels.instance }})"
+      summary: "Chassis cooling fault detected in {{ $labels.instance }}"
+      description: |
+        "Chassis cooling fault detected on {{ $labels.instance }}.
+        {{ if $labels.hostname }}Host: {{ $labels.hostname }}{{ if $labels.model }}, Model: {{ $labels.model }}{{ end }}{{ if $labels.unique_id }}, ID: {{ $labels.unique_id }}{{ end }}{{ else }}Note: Limited system information available{{ end }}"
 
   - alert: IPMI_CMOS_battery
-    expr: ipmi_sensor_state{type="Battery"} == 2
+    expr: |
+      (
+        ipmi_sensor_state{type="Battery"} == 2
+      ) * on (instance) group_left(hostname, model, unique_id) idrac_system_machine_info_fixed
+      or on (instance)
+      (
+        ipmi_sensor_state{type="Battery"} == 2
+      )
     for: 10m
     labels:
       severity: critical
     annotations:
-      summary: "CMOS battery failure {{ $labels.instance }})"
-      description: "CMOS battery failure {{ $labels.instance }})"
+      summary: "CMOS battery failure {{ $labels.instance }}"
+      description: |
+        "CMOS battery failure {{ $labels.instance }}.
+        {{ if $labels.hostname }}Host: {{ $labels.hostname }}{{ if $labels.model }}, Model: {{ $labels.model }}{{ end }}{{ if $labels.unique_id }}, ID: {{ $labels.unique_id }}{{ end }}{{ else }}Note: Limited system information available{{ end }}"
 
   - alert: IPMIScrapeFailed
-    expr: ipmi_up{collector="ipmi"} == 0
+    expr: |
+      (
+        ipmi_up{collector="ipmi"} == 0
+      ) * on (instance) group_left(hostname, model, unique_id) idrac_system_machine_info_fixed
+      or on (instance)
+      (
+        ipmi_up{collector="ipmi"} == 0
+      )
     for: 10m
     labels:
       severity: critical
     annotations:
-      summary: "IPMI Scrape failed for {{ $labels.instance }})"
-      description: "IPMI Scrape failed for {{ $labels.instance }})"
+      summary: "IPMI Scrape failed for {{ $labels.instance }}"
+      description: |
+        "IPMI Scrape failed for {{ $labels.instance }}.
+        {{ if $labels.hostname }}Host: {{ $labels.hostname }}{{ if $labels.model }}, Model: {{ $labels.model }}{{ end }}{{ if $labels.unique_id }}, ID: {{ $labels.unique_id }}{{ end }}{{ else }}Note: Limited system information available{{ end }}"


### PR DESCRIPTION
Fixes #56.

Preserved alerts with safe joining logic for the fallback mechanism.

The `or on` (instance) creates a fallback mechanism:

- Primary path: Try to get rich details via join
- Fallback path: If join fails, still alert with basic info

This way, the alert won't go missing because the query handles potential information loss gracefully. Alert will fire with the best current information