### PR TITLE
Added alert dependencies using `inhibit_rules` in alert manager

### DIFF
--- a/moc-monitoring/base/alert-manager/config/alertmanager.yaml
+++ b/moc-monitoring/base/alert-manager/config/alertmanager.yaml
@@ -22,3 +22,13 @@ receivers:
       {{ range .Alerts }}
         {{ .Annotations.description }}
       {{ end }}
+      
+inhibit_rules:
+  - source_matchers:
+      - scope = "component"
+      - severity =~ "warning|critical"
+    target_matchers:
+      - scope = "system"
+      - severity =~ "warning|critical"
+    equal:
+      - instance

--- a/moc-monitoring/base/prometheus/config/prometheus-rules.yaml
+++ b/moc-monitoring/base/prometheus/config/prometheus-rules.yaml
@@ -14,6 +14,7 @@ groups:
     for: 10m
     labels:
       severity: critical
+      scope: system
     annotations:
       summary: "System health critical for {{ $labels.instance }}"
       description: |
@@ -36,6 +37,7 @@ groups:
     for: 10m
     labels:
       severity: critical
+      scope: component
     annotations:
       summary: "Memory module issue in {{ $labels.instance }}"
       description: |
@@ -47,6 +49,7 @@ groups:
     for: 10m
     labels:
       severity: critical
+      scope: component
     annotations:
       summary: "Drive issue on {{ $labels.instance }}"
       description: |
@@ -58,6 +61,7 @@ groups:
     for: 10m
     labels:
       severity: critical
+      scope: component
     annotations:
       summary: "IPMI PSU redundancy lost on {{ $labels.instance }}"
       description: |
@@ -68,6 +72,7 @@ groups:
     for: 10m
     labels:
       severity: critical
+      scope: component
     annotations:
       summary: "Drive slot issue on {{ $labels.instance }} ({{ $labels.name }})"
       description: |
@@ -78,6 +83,7 @@ groups:
     for: 10m
     labels:
       severity: critical
+      scope: component
     annotations:
       summary: "Chassis cooling fault detected in {{ $labels.instance }})"
       description: "Chassis cooling fault detected on {{ $labels.instance }})"
@@ -87,6 +93,7 @@ groups:
     for: 10m
     labels:
       severity: critical
+      scope: component
     annotations:
       summary: "CMOS battery failure {{ $labels.instance }})"
       description: "CMOS battery failure {{ $labels.instance }})"


### PR DESCRIPTION
Fixes #58
Added `scope` labels to alerts for `inhibit_rules` target matching.
Added `inhibit_rules` for alert dependencies, prioritising component alerts over system alerts.